### PR TITLE
Fix hybrid compilation: private/internal variables should be uniquely renamed before changing visibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AC_CONFIG_FILES([Makefile
                  src/RegionInstrumentation/Makefile
                  src/RegionDump/Makefile
                  src/RegionReplay/Makefile
+                 src/GlobalRename/Makefile
                  src/rdtsc/Makefile
                  src/io_detector/Makefile
                  src/cache_flush/Makefile

--- a/src/GlobalRename/GlobalRename.cpp
+++ b/src/GlobalRename/GlobalRename.cpp
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * This file is part of CERE.                                                *
+ *                                                                           *
+ * Copyright (c) 2013-2016, Universite de Versailles St-Quentin-en-Yvelines  *
+ *                                                                           *
+ * CERE is free software: you can redistribute it and/or modify it under     *
+ * the terms of the GNU Lesser General Public License as published by        *
+ * the Free Software Foundation, either version 3 of the License,            *
+ * or (at your option) any later version.                                    *
+ *                                                                           *
+ * CERE is distributed in the hope that it will be useful,                   *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+ * GNU General Public License for more details.                              *
+ *                                                                           *
+ * You should have received a copy of the GNU General Public License         *
+ * along with CERE.  If not, see <http://www.gnu.org/licenses/>.             *
+ *****************************************************************************/
+//===----------------------------------------------------------------------===//
+//
+// This file renames internal global variable with a unique name to avoid
+// conflicts when setting the visibility to public.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "global-rename"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/Pass.h"
+
+using namespace llvm;
+
+namespace {
+  struct GlobalRename : public ModulePass {
+    bool changed;
+    static char ID; // Pass identification, replacement for typeid
+    GlobalRename() : ModulePass(ID), changed(false) {}
+    virtual bool runOnModule(Module &M);
+  };
+}
+
+char GlobalRename::ID = 0;
+static RegisterPass<GlobalRename> X("global-rename", "Rename global variables", false, false);
+
+bool GlobalRename::runOnModule(Module &M) {
+  //Iterate over global variables
+  for (Module::global_iterator I = M.global_begin(), E = M.global_end();
+                                                      I != E; ++I) {
+    //If this variable is private or internal rename it
+    if ( (I->getLinkage() ==  GlobalValue::PrivateLinkage) || (I->getLinkage() == GlobalValue::InternalLinkage) ) {
+      //Give the module name as variable name, setName handle collisions
+      I->setName(M.getModuleIdentifier());
+      changed = true;
+    }
+  }
+  return changed;
+}

--- a/src/GlobalRename/Makefile.am
+++ b/src/GlobalRename/Makefile.am
@@ -1,0 +1,7 @@
+LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
+libGlobalRename_la_CXXFLAGS = $(LLVMCXXFLAGS)
+
+
+lib_LTLIBRARIES = libGlobalRename.la
+libGlobalRename_la_SOURCES = GlobalRename.cpp
+libGlobalRename_la_LDFLAGS =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS=rdtsc io_detector memory_dump cache_flush RegionOutliner RegionInstrumentation RegionReplay RegionDump
+SUBDIRS=rdtsc io_detector memory_dump cache_flush RegionOutliner RegionInstrumentation RegionReplay RegionDump GlobalRename

--- a/src/ccc/lec/lec.py.in
+++ b/src/ccc/lec/lec.py.in
@@ -23,6 +23,7 @@ LOOP_EXT = "/RegionOutliner/.libs/libRegionOutliner.so"
 LOOP_DUMP = "/RegionDump/.libs/libRegionDump.so"
 LOOP_REPLAY = "/RegionReplay/.libs/libRegionReplay.so"
 LOOP_INSTR = "/RegionInstrumentation/.libs/libRegionInstrumentation.so"
+GLOB_RENAME = "/GlobalRename/.libs/libGlobalRename.so"
 LLVM_BINDIR = "@LLVM_BINDIR@"
 DRAGONEGG_PATH = "@DRAGONEGG_PATH@"
 GCC="@GCC_PATH@"
@@ -154,6 +155,10 @@ def extract_function(mode_opt, regions, BASE):
                  "-isolate-region={loop} {base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
                  LoopExt=LOOP_EXT, loop=to_extract, base=BASE, Omp=OMP_FLAGS), EXIT=False)
 
+          #Rename global variables in this module
+          safe_system(("{llvm_bindir}/opt -S -load {Root}{globRename} -global-rename " +
+                    "{base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
+                    globRename=GLOB_RENAME, base=BASE), EXIT=False)
           #Then extract this function into a new file
           safe_system("llvm-extract -S -func={0} {1}.ll -o {0}.ll".format(to_extract, baseName), EXIT=False)
           safe_system("llvm-extract -S -func={0} {1}.ll -o {1}.ll -delete".format(to_extract, baseName), EXIT=False)
@@ -252,7 +257,7 @@ def last_compil(INCLUDES, SOURCE, BASE, OBJECT, COMPIL_OPT):
           #This prevent from new globals optimizations
           os.system("llc -O3 {base}.ll -o {base}.s".format(opts=" ".join(COMPIL_OPT), base=BASE))
           if "-g" in COMPIL_OPT:
-            COMPIL_OPT.remove("-g")
+            COMPIL_OPT = [x for x in COMPIL_OPT if x != "-g"]
           safe_system("clang -c {opts} {base}.s -o {object}".format(opts=" ".join(COMPIL_OPT),
                          base=BASE, object=OBJECT))
         else:


### PR DESCRIPTION
When extracting multiple regions from different files (for per region
compilation) internal global variables are changed to public visibility
wich causes conflicts at link. This patch renames internal global variables
(before any extraction) with a unique name to avoid names conflict.

Fixes #8
