### PR TITLE
Support for configuration without dragonegg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,9 @@ AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find math library]))
 AC_CHECK_LIB([profiler], [ProfilerStart], , AC_MSG_ERROR([Could not find google profiler library]))
 
 # Check that the selected GCC is compatible with the selected dragonegg
+if test -z "$DRAGONEGG_PATH"; then
+  AC_MSG_NOTICE([Fortran support disabled.])
+else
 AC_MSG_CHECKING([if gcc can compile fortran with dragonegg])
 cat <<EOF >conftest.f90
 module conftest_module
@@ -38,6 +41,7 @@ AC_MSG_RESULT([yes])
 else
 AC_MSG_RESULT([no])
 AC_MSG_ERROR([Your gcc version ($CC) cannot compile Fortran programs with your dragonegg plugin ($DRAGONEGG_PATH)])
+fi
 fi
 
 # Check for common programs and tools

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -151,7 +151,7 @@ llvm::Module *M = new llvm::Module("test", context);]])],
 
     if test -z "$DRAGONEGG_PATH"; then
         AC_MSG_ERROR(
-                [dragonegg.so could not be found at $with_dragonegg_path])
+                [dragonegg.so could not be found at $with_dragonegg_path. Disabling fortran support.])
         DRAGONEGG_PATH=""
     fi
   fi


### PR DESCRIPTION
CERE can be configured and build without dragonegg with
`./configure --without-dragonegg`.

Change-Id: Ia91f195ae2fb7b88136e7fd6692fe57deb01a6f7
