### PR TITLE
Cere trace moves output files instead of copying them.

### DIFF
--- a/src/cere/cere_trace/__init__.py
+++ b/src/cere/cere_trace/__init__.py
@@ -195,8 +195,8 @@ def run(args):
     if not args.norun:
         for region in regions:
             try:
-                shutil.copy("{0}.bin".format(region), "{0}/{1}.bin".format(var.CERE_TRACES_PATH, region))
-                shutil.copy("{0}.csv".format(region), "{0}/{1}.csv".format(var.CERE_TRACES_PATH, region))
+                shutil.move("{0}.bin".format(region), "{0}/{1}.bin".format(var.CERE_TRACES_PATH, region))
+                shutil.move("{0}.csv".format(region), "{0}/{1}.csv".format(var.CERE_TRACES_PATH, region))
             except IOError as err:
                 logger.error(str(err))
                 logger.error("Trace failed for region {0}: No output files, maybe the selected region does not exist.".format(region))


### PR DESCRIPTION
Change-Id: Ic058aeb128045c229d75ea2ece22a4babb4cde6c
