### PR TITLE
Port CERE C libraries to aarch64 

### DIFF
--- a/src/memory_dump/dump.c
+++ b/src/memory_dump/dump.c
@@ -161,7 +161,8 @@ static void fill_dump_name(char *buf, int stack_pos, off64_t addr) {
  * and ending at address <end>
  */
 static bool write_page(char path[], off64_t start) {
-  int out = syscall(SYS_open, path, O_WRONLY | O_CREAT | O_EXCL, S_IRWXU);
+  int out = syscall(SYS_openat, AT_FDCWD, path,
+                    O_WRONLY | O_CREAT | O_EXCL, S_IRWXU);
 
   if (out <= 0) {
     /* region already dumped */
@@ -177,8 +178,9 @@ static bool write_page(char path[], off64_t start) {
 
   int wr = syscall(SYS_write, out, (char *)start, PAGESIZE);
   if (wr < 0) {
-    syscall(SYS_unlink, path);
     syscall(SYS_close, out);
+    int result = syscall(SYS_unlinkat, AT_FDCWD, path, 0);
+    assert(result != -1);
     return false;
   }
   assert(wr == PAGESIZE);
@@ -197,7 +199,7 @@ static bool dump_page(off64_t start) {
     for (int i = 0; i < state.stack_pos; i++) {
       char parent_path[MAX_PATH];
       fill_dump_name(parent_path, i, start);
-      syscall(SYS_link, current_path, parent_path);
+      syscall(SYS_linkat, AT_FDCWD, current_path, AT_FDCWD, parent_path, AT_SYMLINK_FOLLOW);
     }
   }
   return result;
@@ -248,7 +250,8 @@ static void flush_hot_pages_trace_to_disk(void) {
 
   snprintf(path, sizeof(path), "%s/%s", state.dump_path[state.stack_pos],
            state.pagelog_suffix);
-  int out = syscall(SYS_open, path, O_WRONLY | O_CREAT | O_EXCL, S_IRWXU);
+  int out = syscall(SYS_openat, AT_FDCWD, path,
+                    O_WRONLY | O_CREAT | O_EXCL, S_IRWXU);
 
   assert(out > 0);
 
@@ -670,7 +673,8 @@ void dump(char *loop_name, int invocation, int count, ...) {
   /*Link to the original binary*/
   snprintf(lel_bin_path, sizeof(lel_bin_path), "%s/lel_bin",
            state.dump_path[state.stack_pos]);
-  int res = syscall(SYS_link, "lel_bin", lel_bin_path);
+  int res = syscall(SYS_linkat, AT_FDCWD, "lel_bin", AT_FDCWD, lel_bin_path,
+                    AT_SYMLINK_FOLLOW);
   if (res == -1)
     errx(EXIT_FAILURE, "Error copying the dump binary\n");
 

--- a/src/memory_dump/replay.c
+++ b/src/memory_dump/replay.c
@@ -32,7 +32,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include "pages.h"
-#include <emmintrin.h>
 
 /**********************************************************************
  * REPLAY MODE                                                        *

--- a/src/rdtsc/rdtsc.h
+++ b/src/rdtsc/rdtsc.h
@@ -49,14 +49,24 @@ typedef struct
 } region;
 
 __inline__ void serialize(void) {
-    __asm__("cpuid"
+#if defined (__amd64__)
+    __asm__ volatile("cpuid"
             :::"%eax","%ebx","%ecx","%edx");  // clobbered registers
+#elif defined (__aarch64__)
+    __asm__ volatile("isb" : : : "memory");
+#endif
 }
 
 __inline__ unsigned long long int rdtsc() {
-	unsigned long long int a, d;
-	__asm__ volatile ("rdtsc" : "=a" (a), "=d" (d));
-	return (d<<32) | a;
+    unsigned long long int a, d;
+
+#if defined(__amd64__)
+    __asm__ volatile ("rdtsc" : "=a" (a), "=d" (d));
+    return (d<<32) | a;
+#elif defined(__aarch64__)
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r" (a));
+    return a;
+#endif
 }
 
 static uint32_t hash_string(const char*);


### PR DESCRIPTION
This PR tracks the port for CERE C libraries to aarch64.
- Write aarch64 assembly intrinsics for reading TSC and doing a memory barrier.
- Replace obsolete SYS_open, etc. syscalls
