### PR TITLE
Fix memory dump issue

### DIFF
--- a/src/ccc/lel/Template_realmain.c
+++ b/src/ccc/lel/Template_realmain.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <assert.h>
+#include <unistd.h>
 
 void anti_dead_code_elimination(int n, ...) {{}}
 void sigcatch(int signal) {{

--- a/src/memory_dump/pages.h
+++ b/src/memory_dump/pages.h
@@ -20,4 +20,5 @@
 #define CACHELINESIZE 16
 #define round_to_page(addr)                                                    \
   ((char *)(((long unsigned)(addr)) & ~(PAGESIZE - 1)))
-#define round_up_page(size) ((((size) - 1) / PAGESIZE + 1) * PAGESIZE)
+#define round_up_page(addr) ((((long unsigned)(addr) - 1) / PAGESIZE + 1) * PAGESIZE)
+#define nb_pages_in_range(from, to) (((long unsigned)round_up_page(to) - (long unsigned)round_to_page(from))/PAGESIZE)


### PR DESCRIPTION
Memory allocation functions in memory_dump/hooks.c did not lock the last
page in a newly allocated range. This commit bug fixes this bug and
factors the region locking code.
