### PR TITLE
Add region prototype to template to avoid warning

### DIFF
--- a/src/ccc/lel/Template_realmain.c
+++ b/src/ccc/lel/Template_realmain.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <unistd.h>
 
+void run{loop}(void);
 void anti_dead_code_elimination(int n, ...) {{}}
 void sigcatch(int signal) {{
   fprintf(stderr, "Timeout...\n");


### PR DESCRIPTION
`Template_realmain.c` should have a region prototype to avoid
compiler warnings.
