### PR TITLE
Fix truncated relocation problems in aarch64

### DIFF
--- a/src/ccc/lel/lel.py.in
+++ b/src/ccc/lel/lel.py.in
@@ -73,7 +73,7 @@ def create_user_main(mode_opt,LOOP):
     MAIN.close()
 
 def compile_memory_dump_objects(DIR):
-    DUMP_ARGS="-Wl,--section-start=.text=0x60000000"
+    DUMP_ARGS="-Wl,--section-start=.text=0x60004000 -Wl,--section-start=.init=0x60000000"
     safe_system("rm -f {0}/objs.S".format(DUMPS_DIR))
     OBJ=open("{0}/objs.S".format(DUMPS_DIR),'w')
     for FILE in os.listdir(DIR):


### PR DESCRIPTION
In aarch64, calls are limited to a +-128Mb range. When generating
the replay binary the .text section is relocated in a high address
0x60000000 to make place for the captured static (.data and .bss)
segments.

This patch also relocates the .init section close to 0x60000000 to
avoid stepping over the +-128Mb function call range.
