### PR TITLE
Fix an issue with cere regions

### DIFF
--- a/src/cere/cere_capture/__init__.py
+++ b/src/cere/cere_capture/__init__.py
@@ -111,7 +111,7 @@ def run(args):
   else:
     logger.info("Compiling capture mode for all regions")
     try:
-      logger.debug(subprocess.check_output("{0} && {1} CERE_MODE=\"dump --regions-infos={2}\"".format(cere_configure.cere_config["clean_cmd"],
+      logger.debug(subprocess.check_output("{0} && {1} CERE_MODE=\"dump --region=\"all\" --regions-infos={2}\"".format(cere_configure.cere_config["clean_cmd"],
                           cere_configure.cere_config["build_cmd"], cere_configure.cere_config["regions_infos"]), stderr=subprocess.STDOUT, shell=True))
     except subprocess.CalledProcessError as err:
       logger.error(str(err))


### PR DESCRIPTION
Cere regions calls cere dump in global dump mode to find all extractible regions
of the application. With recent change to ccc, dump mode needs a region to be
specified to forbid the global dump. Adding --region="all" fixed the problem.

Fix #56 

Change-Id: I0f382ef51569e8769ed2dc8156ddfe315649d050
