### PR TITLE
Fix DIST targets in automake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
 SUBDIRS=src/ tests/ doc/
 ACLOCAL_AMFLAGS=-I m4
-bin_SCRIPTS=cere
+EXTRA_DIST=examples/
+dist_bin_SCRIPTS=cere

--- a/src/RegionDump/Makefile.am
+++ b/src/RegionDump/Makefile.am
@@ -3,5 +3,4 @@ libcere_regiondump_la_CXXFLAGS = $(LLVMCXXFLAGS)
 
 
 lib_LTLIBRARIES = libcere_regiondump.la
-libcere_regiondump_la_SOURCES = RegionDump.cpp LoopRegionDump.cpp OmpRegionDump.cpp
-libcere_regiondump_la_LDFLAGS =
+libcere_regiondump_la_SOURCES = RegionDump.cpp LoopRegionDump.cpp OmpRegionDump.cpp RegionDump.h

--- a/src/RegionInstrumentation/Makefile.am
+++ b/src/RegionInstrumentation/Makefile.am
@@ -3,5 +3,4 @@ libcere_regioninstrumentation_la_CXXFLAGS = $(LLVMCXXFLAGS)
 
 
 lib_LTLIBRARIES = libcere_regioninstrumentation.la
-libcere_regioninstrumentation_la_SOURCES = RegionInstrumentation.cpp LoopRegionInstrumentation.cpp OmpRegionInstrumentation.cpp
-libcere_regioninstrumentation_la_LDFLAGS =
+libcere_regioninstrumentation_la_SOURCES = RegionInstrumentation.cpp LoopRegionInstrumentation.cpp OmpRegionInstrumentation.cpp RegionInstrumentation.h

--- a/src/RegionOutliner/Makefile.am
+++ b/src/RegionOutliner/Makefile.am
@@ -3,5 +3,4 @@ libcere_regionoutliner_la_CXXFLAGS = $(LLVMCXXFLAGS)
 
 
 lib_LTLIBRARIES = libcere_regionoutliner.la
-libcere_regionoutliner_la_SOURCES = RegionExtractor.cpp LoopRegionOutliner.cpp OmpRegionOutliner.cpp
-libcere_regionoutliner_la_LDFLAGS =
+libcere_regionoutliner_la_SOURCES = RegionExtractor.cpp LoopRegionOutliner.cpp OmpRegionOutliner.cpp RegionExtractor.h

--- a/src/RegionReplay/Makefile.am
+++ b/src/RegionReplay/Makefile.am
@@ -3,5 +3,4 @@ libcere_regionreplay_la_CXXFLAGS = $(LLVMCXXFLAGS)
 
 
 lib_LTLIBRARIES = libcere_regionreplay.la
-libcere_regionreplay_la_SOURCES = RegionReplay.cpp LoopRegionReplay.cpp OmpRegionReplay.cpp
-libcere_regionreplay_la_LDFLAGS =
+libcere_regionreplay_la_SOURCES = RegionReplay.cpp LoopRegionReplay.cpp OmpRegionReplay.cpp RegionReplay.h

--- a/src/io_detector/Makefile.am
+++ b/src/io_detector/Makefile.am
@@ -1,4 +1,4 @@
 lib_LTLIBRARIES = libcere_iodetector.la
 libcere_iodetector_la_CFLAGS = --std=gnu99 -I ../ccan/
-libcere_iodetector_la_SOURCES = io_detector.c io_detection_wrapper.c
+libcere_iodetector_la_SOURCES = io_detector.c io_detection_wrapper.c io_detector.h
 libcere_iodetector_la_LIBADD = ../ccan/libccan.la

--- a/src/memory_dump/Makefile.am
+++ b/src/memory_dump/Makefile.am
@@ -1,7 +1,11 @@
 lib_LTLIBRARIES = libcere_dump.la libcere_load.la
 libcere_dump_la_CFLAGS = --std=gnu99 -I ../ccan/ -Wl,-z,now,-z,relro
-libcere_dump_la_SOURCES = hooks.c dump.c counters.c
+libcere_dump_la_SOURCES = hooks.c dump.c counters.c counters.h dump.h pages.h
 libcere_dump_la_LIBADD = ../ccan/libccan.la
 
+
 libcere_load_la_CFLAGS = --std=gnu99 -Wl,-z,now,-z,relro
-libcere_load_la_SOURCES = replay.c
+libcere_load_la_SOURCES = replay.c pages.h
+
+
+

--- a/src/rdtsc/Makefile.am
+++ b/src/rdtsc/Makefile.am
@@ -1,4 +1,4 @@
 lib_LTLIBRARIES = libcere_rdtsc.la
 libcere_rdtsc_la_CFLAGS = --std=gnu99 -I ../ccan/
-libcere_rdtsc_la_SOURCES = rdtsc.c rdtsc_wrapper.c
+libcere_rdtsc_la_SOURCES = rdtsc.c rdtsc_wrapper.c rdtsc.h
 libcere_rdtsc_la_LIBADD = ../ccan/libccan.la


### PR DESCRIPTION
Fixed dist targets, so we can build a complete release tarball with make dist.
