### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,21 @@
 CERE CHANGELOG
 
+[v0.2.0] 2016/05/19
+    * Fixed autotools installation: now CERE can and must be installed
+      with make install. All libraries were renamed with a common libcere_
+      prefix. (#6)
+    * ccc is now called cerec (cere compiler)
+    * Fixed the documentation and renamed some configuration variables.
+      To set the replay repetitions now one should use CERE_REPLAY_REPETITIONS.
+      To choose the warmup mode one can configure CERE_WARMUP.
+    * Fixed a capture/replay bug that could happen when global static variables
+      were optimized during capture but not replay. (#51)
+    * Cere flags now accepts a file of flags combinations (#24)
+    * Removed the undocumented and unused dump-all mode.
+    * Fixed an issue with the report generation coverage plot.
+    * Fixed various bugs in cere python driver.
+    * Added various missing tests.
+
 [v0.1.0] 2016/02/24
     * Compatibility with LLVM 3.5 (LLVM 3.3 and LLVM 3.4 are still
       supported).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CERE v0.1.0
+# CERE v0.2.0
 
 [![Build Status](https://travis-ci.org/benchmark-subsetting/cere.svg?branch=master)](https://travis-ci.org/benchmark-subsetting/cere)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([cere], [0.1.0], [cere-dev@googlegroups.com])
+AC_INIT([cere], [0.2.0], [cere-dev@googlegroups.com])
 AM_SILENT_RULES([yes])
 AC_CONFIG_AUX_DIR(autoconf)
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
- Fixed autotools installation: now CERE can and must be installed
    with make install. All libraries were renamed with a common libcere_
    prefix. (#6)
- ccc is now called cerec (cere compiler)
- Fixed the documentation and renamed some configuration variables.
    To set the replay repetitions now one should use CERE_REPLAY_REPETITIONS.
    To choose the warmup mode one can configure CERE_WARMUP.
- Fixed a capture/replay bug that could happen when global static variables
    were optimized during capture but not replay. (#51)
- Cere flags now accepts a file of flags combinations (#24)
- Removed the undocumented and unused dump-all mode.
- Fixed an issue with the report generation coverage plot.
- Fixed various bugs in cere python driver.
- Added various missing tests.
