### PR TITLE
Simplified llvm dump pass.

### DIFF
--- a/src/RegionDump/LoopRegionDump.cpp
+++ b/src/RegionDump/LoopRegionDump.cpp
@@ -35,6 +35,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/IRBuilder.h>
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
@@ -43,13 +45,6 @@
 #include <fstream>
 #include <set>
 #include "RegionDump.h"
-
-#if LLVM_VERSION_MINOR >= 5
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/Dominators.h"
-#else
-#include "llvm/Support/InstIterator.h"
-#endif
 
 using namespace llvm;
 

--- a/src/RegionDump/OmpRegionDump.cpp
+++ b/src/RegionDump/OmpRegionDump.cpp
@@ -36,6 +36,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/IRBuilder.h>
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
@@ -44,13 +46,6 @@
 #include <fstream>
 #include <set>
 #include "RegionDump.h"
-
-#if LLVM_VERSION_MINOR >= 5
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/Dominators.h"
-#else
-#include "llvm/Support/InstIterator.h"
-#endif
 
 using namespace llvm;
 

--- a/src/RegionDump/RegionDump.cpp
+++ b/src/RegionDump/RegionDump.cpp
@@ -34,6 +34,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/IRBuilder.h>
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/DebugInfo.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
@@ -42,13 +44,6 @@
 #include <fstream>
 #include <set>
 #include "RegionDump.h"
-
-#if LLVM_VERSION_MINOR >= 5
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/DebugInfo.h"
-#else
-#include "llvm/Support/InstIterator.h"
-#endif
 
 using namespace llvm;
 


### PR DESCRIPTION
Dump pass is only compatible with llvm-3.8

Change-Id: If4df74b7ffd3ba62469a1ed94f5bdb15d1171ca4
