### PR TITLE
Record link between omp regions and cere regions

### DIFF
--- a/src/RegionOutliner/RegionExtractor.cpp
+++ b/src/RegionOutliner/RegionExtractor.cpp
@@ -413,21 +413,6 @@ void RegionExtractor::add_region_to_file(
     //~return StringRef("indirect call");
 //~}
 
-/// Find omp microtask name for the parralel region
-std::string findMicrotaskName(CallInst *callInst) {
-  std::string str;
-  llvm::raw_string_ostream rso(str);
-  callInst->print(rso);
-
-  size_t place = str.find(".omp_microtask.");
-  if (place == std::string::npos) {
-    exit(0);
-  } else {
-    size_t place2 = str.substr(place).find(" ");
-    return str.substr(place, place2);
-  }
-}
-
 /// \brief Creates the CERE formated function name for the outlined region.
 /// The syntax is __cere__filename__functionName__firstLine
 std::string RegionExtractor::createFunctionName(Function *oldFunction,

--- a/src/cere/cere_profile.py
+++ b/src/cere/cere_profile.py
@@ -89,6 +89,9 @@ def instrument_application(run_cmd, build_cmd, clean_cmd, force):
     if not os.path.isfile("{0}/app.prof".format(var.CERE_PROFILE_PATH)):
         logger.critical("Instrumentation failed: No output file")
         return False
-    logger.info('Instrumentation success')
-    create_graph(force)
+
+    if not create_graph(force):
+      logger.error("Call graph creation failed.")
+      return False
+    logger.info('Profile success')
     return True

--- a/src/cere/create_graph.py
+++ b/src/cere/create_graph.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import shutil
 import subprocess
 import cere_configure
 import logging
@@ -185,6 +186,14 @@ def create_graph(force):
     except subprocess.CalledProcessError as err:
         logger.error(str(err))
         logger.error(err.output)
+        return False
+
+    if cere_configure.cere_config["omp"]:
+      try:
+        shutil.move("omp_outlined_to_cere", "{0}/omp_outlined_to_cere".format(var.CERE_PROFILE_PATH))
+      except IOError as err:
+        logger.error(str(err))
+        logger.error("File containing connection between OpenMP regions and cere regions is missing.")
         return False
 
     binary = which(run_cmd)


### PR DESCRIPTION
CERE outline pass dumps a file where we link each cere region to the
corresponding OMP region. This is usefull to understand what is really
executed by the cere region.
