### PR TITLE
Fix graph creation for CERE OMP

### DIFF
--- a/src/cere/cere_instrument.py
+++ b/src/cere/cere_instrument.py
@@ -50,7 +50,7 @@ def run_instrument(args_region=None, args_regions_file=None, args_plugin_instr=v
         logger.error("No region specified, use at least one of the following: --region, --regions-file")
         return False
 
-    if (cere_configure.cere_config["omp"]) and ("OMP_NUM_THREADS" not in os.environ) and (not args.norun):
+    if (cere_configure.cere_config["omp"]) and ("OMP_NUM_THREADS" not in os.environ) and (not args_norun):
       logger.error("OMP_NUM_THREADS not set. Export OMP_NUM_THREADS first.")
       return False
 


### PR DESCRIPTION
The command cere profile outputs an empty call graph because cere regions
are too small with omp enable since they only contain a call to a parallel
omp region. Cere regions are added manually in the call graph before there
respective omp region.

Change-Id: I7bd22943fde63e49ee67b61e1e606179d405f702
