### PR TITLE
Avoid measuring OMP regions when measuring application cycles.

### DIFF
--- a/src/RegionInstrumentation/OmpRegionInstrumentation.cpp
+++ b/src/RegionInstrumentation/OmpRegionInstrumentation.cpp
@@ -131,7 +131,8 @@ bool OmpRegionInstrumentation::runOnFunction(Function &F) {
   prepareInstrumentation(F, RegionFile, MeasureAppli, Mode, RequestedInvoc);
   Module *mod = F.getParent();
 
-  insertOmpProbe(mod, &F);
+  if(!MeasureAppli)
+    insertOmpProbe(mod, &F);
 
   return true;
 }


### PR DESCRIPTION
In OMP mode, omp regions where instrumented even when measuring application
cycles resulting in nested instrumentation and multiple output files that
were not processed.

Change-Id: Ifba1f81fa7a3bb067c7e219646f9b3ae381ec4cb
