### PR TITLE
Optimization of memory capture

### DIFF
--- a/src/memory_dump/hooks.c
+++ b/src/memory_dump/hooks.c
@@ -151,8 +151,8 @@ static void touch_string(const char *str) {
  */
 static void touch_mem(const void *mem, size_t size, size_t nmemb) {
   size_t i;
-  char* last = ((char*)mem)+size*nmemb-1;
-  for (char *c = (char*) mem; c <= last; c+=PAGESIZE) {
+  char *last = ((char *)mem) + size * nmemb - 1;
+  for (char *c = (char *)mem; c <= last; c += PAGESIZE) {
     volatile char touched = *c;
   }
   volatile char touched = *last;

--- a/src/memory_dump/pages.h
+++ b/src/memory_dump/pages.h
@@ -28,7 +28,7 @@
 
 /* rounds up an address to the upper page address */
 #define round_up_page(addr)                                                    \
-  ((char*)((((long unsigned)(addr)-1) / PAGESIZE + 1) * PAGESIZE))
+  ((char *)((((long unsigned)(addr)-1) / PAGESIZE + 1) * PAGESIZE))
 
 /* number of memory pages that contain the memory range [from;to] */
 #define nb_pages_in_range(from, to)                                            \

--- a/src/memory_dump/ptrace.h
+++ b/src/memory_dump/ptrace.h
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 #include <sys/user.h>
 
-
 /* Wrapper interface for ptrace calls.
  * The following functions, wrap the equivalent ptrace
  * calls and perform error checking */
@@ -57,7 +56,6 @@ void *ptrace_ripat(pid_t pid, void *addr);
 
 void ptrace_syscall(pid_t pid);
 void ptrace_syscall_flag(pid_t pid, int flag);
-
 
 siginfo_t wait_process(pid_t pid);
 

--- a/src/memory_dump/syscall_interface.h
+++ b/src/memory_dump/syscall_interface.h
@@ -25,7 +25,8 @@
 
 void protect(pid_t pid, char *start, size_t size);
 void unprotect(pid_t pid, char *start, size_t size);
-void unprotect_state(pid_t pid, char *start, size_t size);
+void unprotect_protect(pid_t pid, char *start_u, size_t size_u, char *start_p,
+                       size_t size_p);
 void write_page(pid_t pid, int fd, const void *buf, size_t nbyte);
 int openat_i(pid_t pid, char *pathname);
 void close_i(pid_t pid, int fd);

--- a/src/memory_dump/types.h
+++ b/src/memory_dump/types.h
@@ -28,10 +28,13 @@
 #define LOG_SIZE 64
 #define SIZE_LOOP 256
 #define CALLOC_INIT 512
-#define OFFSET_STR 0x100 /* Offset for write string */
 
-#define SYS_dump (INT_MAX-1)
-#define SYS_hook (INT_MAX-2)
+#define SYS_dump (INT_MAX - 1)
+#define SYS_hook (INT_MAX - 2)
+#define SYS_unprotect_protect (INT_MAX - 3)
+
+#define SIZE_SYSCALL_BIN (3 + 1)
+#define SIZE_UNPROTECT_PROTECT_BIN (23 + 1)
 
 enum tracer_state_t {
   TRACER_UNLOCKED = 1,
@@ -40,5 +43,21 @@ enum tracer_state_t {
 };
 
 extern enum tracer_state_t tracer_state;
+
+struct tracee_buff_t {
+  char syscall[SIZE_SYSCALL_BIN];
+  char unprotect_protect[SIZE_UNPROTECT_PROTECT_BIN];
+  char str_tmp[MAX_PATH];
+} __attribute__((packed));
+
+extern struct tracee_buff_t tracee_buff;
+
+struct tracer_buff_t {
+  char *syscall;
+  char *unprotect_protect;
+  char *str_tmp;
+};
+
+extern struct tracer_buff_t tracer_buff;
 
 #endif /* __TYPES__H */


### PR DESCRIPTION
- Add structur tracee_buff_t and tracer_buff_t that permit to avoid calls to some ptrace functions
- Fusion of two syscalls in one small binary code (unprotect_protect)
- Fix a bug on ptrace_getdata that cause crash
- Delete ptrace_ripat function, no more need
