### PR TITLE
LLVM_CPPFLAGS should only be defined once at configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,7 @@ AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path for dragonegg])
 AC_SUBST(GCC_PATH, $CC)
 
 AX_LLVM([3.3],[3.5.2],[all])
+AC_SUBST(LLVM_CPPFLAGS, $LLVM_CPPFLAGS)
 
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
 AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find math library]))

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -83,6 +83,7 @@ AC_DEFUN([AX_LLVM],
   LLVM_BINDIR=`$LLVM_CONFIG --bindir`
   AC_DEFINE_UNQUOTED([LLVM_BINDIR], ["$LLVM_BINDIR"], [The llvm bin dir])
   LLVM_CPPFLAGS=`$LLVM_CONFIG --cxxflags`
+  AC_DEFINE_UNQUOTED([LLVM_CPPFLAGS], ["$LLVM_CPPFLAGS"], [The llvm CPPFLAGS])
   if test "$LLVM_VERSION_MINOR" = 5; then
     LLVM_LDFLAGS=`$LLVM_CONFIG --system-libs`
   else

--- a/src/GlobalRename/Makefile.am
+++ b/src/GlobalRename/Makefile.am
@@ -1,5 +1,4 @@
-LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
-libcere_globalrename_la_CXXFLAGS = $(LLVMCXXFLAGS)
+libcere_globalrename_la_CXXFLAGS = @LLVM_CPPFLAGS@
 
 
 lib_LTLIBRARIES = libcere_globalrename.la

--- a/src/RegionDump/Makefile.am
+++ b/src/RegionDump/Makefile.am
@@ -1,5 +1,4 @@
-LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
-libcere_regiondump_la_CXXFLAGS = $(LLVMCXXFLAGS)
+libcere_regiondump_la_CXXFLAGS = @LLVM_CPPFLAGS@
 
 
 lib_LTLIBRARIES = libcere_regiondump.la

--- a/src/RegionInstrumentation/Makefile.am
+++ b/src/RegionInstrumentation/Makefile.am
@@ -1,5 +1,4 @@
-LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
-libcere_regioninstrumentation_la_CXXFLAGS = $(LLVMCXXFLAGS)
+libcere_regioninstrumentation_la_CXXFLAGS = @LLVM_CPPFLAGS@
 
 
 lib_LTLIBRARIES = libcere_regioninstrumentation.la

--- a/src/RegionOutliner/Makefile.am
+++ b/src/RegionOutliner/Makefile.am
@@ -1,5 +1,4 @@
-LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
-libcere_regionoutliner_la_CXXFLAGS = $(LLVMCXXFLAGS)
+libcere_regionoutliner_la_CXXFLAGS = @LLVM_CPPFLAGS@
 
 
 lib_LTLIBRARIES = libcere_regionoutliner.la

--- a/src/RegionReplay/Makefile.am
+++ b/src/RegionReplay/Makefile.am
@@ -1,5 +1,4 @@
-LLVMCXXFLAGS    := $(shell "$(LLVM_CONFIG)" --cxxflags)
-libcere_regionreplay_la_CXXFLAGS = $(LLVMCXXFLAGS)
+libcere_regionreplay_la_CXXFLAGS = @LLVM_CPPFLAGS@
 
 
 lib_LTLIBRARIES = libcere_regionreplay.la


### PR DESCRIPTION
It's better to call `llvm-config --cppflags` only once. It also makes it easier to substitute this value during configure.
