### PR TITLE
Restore previous version of check io test

### DIFF
--- a/tests/test_check_io/test.c
+++ b/tests/test_check_io/test.c
@@ -12,8 +12,8 @@ int main(int argc, char **argv)
     fflush(f);
   }
   rewind(f);
-  char str[256];
   for(i = 0; i < 2; i ++) {
+    char str[256];
     fscanf(f, "%s", str);
     printf("I read %s\n", str);
   }

--- a/tests/test_check_io/test.sh
+++ b/tests/test_check_io/test.sh
@@ -10,7 +10,7 @@ function do_test()
       cere capture --region="$region" --invocation 1
     done
 
-    if ! grep "__cere__test_main_16" .cere/replays/invalid_regions ; then
+    if ! grep "__cere__test_main_15" .cere/replays/invalid_regions ; then
       return 1
     fi
 


### PR DESCRIPTION
Since llvm 3.8 this check fails if we don't disable the IR verification
pass. In the previous commit we actually disabled IR verification so we
can keep this test as a reminder for this issue.
