### PR TITLE
Fix cere-replay call from cere-check-matching

### DIFF
--- a/src/cere/cere_check_matching.py
+++ b/src/cere/cere_check_matching.py
@@ -65,6 +65,7 @@ class Region():
         self.read = False
         self.regions_file = None
         self.noinstrumentation = False
+        self.static = False
         self.plugin_instr=var.RDTSC_WRAPPER
         self.force = False
         self.invocations_data = []


### PR DESCRIPTION
cere-check-matching initialize the replay --static argument before calling
it.

Fix #133