### PR TITLE
Renamed CERE_PATH to CERE_WORKING_PATH 

### DIFF
--- a/src/cere/cere_configure.py
+++ b/src/cere/cere_configure.py
@@ -42,8 +42,7 @@ def run(args):
     cere_config["run_cmd"] = args.run_cmd
     cere_config["clean_cmd"] = args.clean_cmd
     cere_config["multiple_trace"] = args.multiple_trace
-    cere_config["regions_infos"] = os.path.realpath(args.regions_infos)
-    cere_config["cere_path"] = os.path.realpath(var.CERE_MAIN_DIR)
+    cere_config["regions_infos"] = args.regions_infos
 
     with open("cere.json", 'w') as config_file:
         json.dump(cere_config, config_file)
@@ -60,7 +59,7 @@ def init():
     if not setup_dir():
         logger.critical("Cannot create required directories for CERE. Check permissions?")
         return False
-    os.environ["CERE_PATH"] = cere_config["cere_path"]
+    os.environ["CERE_WORKING_PATH"] = os.path.realpath(var.CERE_MAIN_DIR)
     return True
 
 def setup_dir():

--- a/src/cere/lel.py
+++ b/src/cere/lel.py
@@ -177,14 +177,13 @@ def extract_symbols(DIR):
                     objcopy=OBJCOPY, dump_dir=DIR))
 
 def find_cere_dir():
-  if "CERE_PATH" in os.environ:
-    return os.path.dirname(os.environ["CERE_PATH"])
-  file_name = ".cere" #file to be searched
+  if "CERE_WORKING_PATH" in os.environ:
+    return os.path.dirname(os.environ["CERE_WORKING_PATH"])
   cur_dir = os.getcwd()
   while True:
     file_list = os.listdir(cur_dir)
     parent_dir = os.path.dirname(cur_dir)
-    if file_name in file_list: break
+    if CERE_MAIN_DIR in file_list: break
     else:
       if "cere.json" in file_list or cur_dir == parent_dir:
         return False


### PR DESCRIPTION
CERE_PATH is renamed to CERE_WORKING_PATH to avoid ambiguities. Also
cere working path is not stored anymore in cere.json.