### PR TITLE
Support for llvm up to version 3.9.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_MAKE_SET
 AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path for dragonegg])
 AC_SUBST(GCC_PATH, $CC)
-AX_LLVM([3.8.0],[3.9.0],[all])
+AX_LLVM([3.8.0],[3.9.1],[all])
 
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
 AC_CHECK_LIB([gfortran], [exit], , AC_MSG_ERROR([Could not find gfortran library]))

--- a/src/ccc/lec/lec.py.in
+++ b/src/ccc/lec/lec.py.in
@@ -95,10 +95,10 @@ def dump_fun(mode_opt, BASE, regions):
     if(mode_opt.invocation):
         temp = temp+"--invocation="+mode_opt.invocation+" "
     safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopExt} {Omp}-region-outliner " +
-                "-regions-infos={regions_infos} {base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
+                "-regions-infos={regions_infos} {base}.ll -o {base}.ll -disable-verify").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
                 LoopExt=LOOP_EXT, regions_infos=mode_opt.regions_infos, base=BASE,Omp=OMP_FLAGS), EXIT=False)
     safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopMan} {Omp}-region-dump {opts} " +
-                "{base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
+                "{base}.ll -o {base}.ll -disable-verify").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
                 LoopMan=LOOP_DUMP, opts=temp, base=BASE,Omp=OMP_FLAGS), EXIT=False)
 
 #in replay mode
@@ -115,7 +115,7 @@ def replay_fun(mode_opt, BASE, regions):
     if (mode_opt.invocation):
         temp = temp + "--invocation=" + mode_opt.invocation + " "
     safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopExt} {Omp}-region-outliner " +
-                "-isolate-region={loop} {base}.ll -o {base}.ll").format(
+                "-isolate-region={loop} {base}.ll -o {base}.ll -disable-verify").format(
                 llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT, LoopExt=LOOP_EXT,
                 loop=mode_opt.region, base=BASE,Omp=OMP_FLAGS), EXIT=False)
     safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopMan} {opts} {Omp}-region-replay -region={loop} " +
@@ -152,7 +152,7 @@ def extract_function(mode_opt, regions, BASE):
             to_extract=region
             #Outline the loop into a function
             safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopExt} {Omp}-region-outliner " +
-                 "-isolate-region={loop} {base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
+                 "-isolate-region={loop} {base}.ll -o {base}.ll -disable-verify").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
                  LoopExt=LOOP_EXT, loop=to_extract, base=BASE, Omp=OMP_FLAGS), EXIT=False)
 
           #Rename global variables in this module
@@ -203,7 +203,7 @@ def original_fun(mode_opt, BASE, regions):
     if(mode_opt.instrument):
         if(mode_opt.instrument_app):
             safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopExt} {Omp}-region-outliner {opts} " +
-                "{base}.ll -o {base}.ll").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
+                "{base}.ll -o {base}.ll -disable-verify").format(llvm_bindir=LLVM_BINDIR, Root=PROJECT_ROOT,
                 LoopExt=LOOP_EXT, opts=extract_opts, base=BASE,Omp=OMP_FLAGS), EXIT=False)
         else:
             safe_system(("{llvm_bindir}/opt -S -load {Root}{LoopInstr} " +
@@ -239,7 +239,7 @@ def last_compil(INCLUDES, SOURCE, BASE, OBJECT, COMPIL_OPT):
     '''
     # Optionnal midend optimizations to explore
     if (MIDEND_FLAGS):
-        os.system("{llvm_bindir}/opt -S {midend_flags} {base}.ll -o {base}.ll".format(
+        os.system("{llvm_bindir}/opt -S {midend_flags} {base}.ll -o {base}.ll -disable-verify".format(
                      llvm_bindir=LLVM_BINDIR, midend_flags=MIDEND_FLAGS, base=BASE))
 
     # Can choose llc as llvm backend
@@ -251,7 +251,7 @@ def last_compil(INCLUDES, SOURCE, BASE, OBJECT, COMPIL_OPT):
         if REGION_EXTRACTED:
           #Regions have been extracted from this file. So we must change globals
           #definitions.
-          safe_system("opt -S -O3 {base}.ll -o {base}.ll".format(opts=" ".join(COMPIL_OPT),
+          safe_system("opt -S -O3 {base}.ll -o {base}.ll -disable-verify".format(opts=" ".join(COMPIL_OPT),
                          base=BASE))
           os.system("sed -i 's/internal constant/hidden constant/' {base}.ll".format(base=BASE))
           #This prevent from new globals optimizations


### PR DESCRIPTION
* Support llvm-3.9.1
* Disabled IR verification after extracting loops to avoid errors with
wrong metadata for debug information.
