### PR TITLE
Compatibility with llvm 3.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: required
 dist: trusty
 
 before_install:
-  # Get llvm 3.8
-  - wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  - tar -xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  - export PATH=$PWD/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin/:$PATH
-  - export LIBRARY_PATH=$PWD/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/lib/:$LIBRARY_PATH
+  # Get llvm 3.9
+  - wget http://releases.llvm.org/3.9.0/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  - tar -xf clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  - export PATH=$PWD/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-14.04/bin/:$PATH
+  - export LIBRARY_PATH=$PWD/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-14.04/lib/:$LIBRARY_PATH
 
   - sudo apt-get -y install autoconf automake build-essential libtool
     python python-pip python-sklearn python-pygraphviz python-pydot libiomp-dev

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_SUBST(CERELIBS, $libdir)
 AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path for dragonegg])
 AC_SUBST(GCC_PATH, $CC)
-AX_LLVM([3.8.0],[3.8.1],[all])
+AX_LLVM([3.8.0],[3.9.1],[all])
 AC_SUBST(LLVM_CPPFLAGS, $LLVM_CPPFLAGS)
 
 

--- a/src/RegionOutliner/RegionExtractor.cpp
+++ b/src/RegionOutliner/RegionExtractor.cpp
@@ -651,6 +651,7 @@ bool checkMDNode(MDNode  &MD, Function * newFunction) {
 /// https://weaponshot.wordpress.com/2012/05/06/extract-all-the-metadata-nodes-in-llvm/
 void RegionExtractor::removeWrongMetadata(Function *newFunction) {
   std::vector<CallInst *> InstToDel;
+  MDNodes.clear();
 
   // Iterate over instructions of the function
   for (Function::iterator BB = newFunction->begin(), E = newFunction->end();
@@ -660,10 +661,8 @@ void RegionExtractor::removeWrongMetadata(Function *newFunction) {
       // If this instruction is a call
       if (CallInst *CI = dyn_cast<CallInst>(I)) {
         if (Function *F = CI->getCalledFunction()){
-          errs() << F->getName() << "\n";
           for (unsigned i = 0, e = I->getNumOperands(); i != e; ++i) {
             // Get Metadata information
-            errs() << *(I->getOperand(i)) << "\n";
             auto *MDV = dyn_cast<MetadataAsValue>(I->getOperand(i));
             if (!MDV) continue;
 


### PR DESCRIPTION
* This PR allows to compile CERE against llvm version up to 3.9.0
* Removed useless prints from Outline pass.