### PR TITLE
Aarch64 port of the ptrace memory tracer

### DIFF
--- a/src/cere/lel.py
+++ b/src/cere/lel.py
@@ -69,7 +69,7 @@ def compile_memory_dump_objects(mode_opt, DIR):
     if not mode_opt.static:
         DUMP_ARGS="-Wl,--section-start=.text=0x60004000 -Wl,--section-start=.init=0x60000000"
     else:
-        DUMP_ARGS=""
+        DUMP_ARGS="-Wl,--section-start=.text=0x6004000 -Wl,--section-start=.init=0x6000000"
     safe_system("rm -f {0}/objs.S".format(DIR))
     OBJ=open("{0}/objs.S".format(DIR),'w')
     for FILE in os.listdir(DIR):

--- a/src/memory_dump/cere_tracer.c
+++ b/src/memory_dump/cere_tracer.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines       *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/cere_tracer.c
+++ b/src/memory_dump/cere_tracer.c
@@ -107,15 +107,13 @@ static void read_map(pid_t pid) {
 }
 
 static bool is_valid_io(pid_t pid) {
-  return true;
-  // XXX Comment for now in AARCH64
-  /*
-  struct user_regs_struct regs;
-  ptrace_getregs(pid, &regs);
-  int syscallid = regs.orig_rax;
+  int syscallid = get_syscallid(pid);
+  int fd;
+
   switch (syscallid) {
   case SYS_write:
-    return (regs.rdi == fileno(stdout) || regs.rdi == fileno(stderr));
+    fd = get_arg_from_regs(pid);
+    return (fd == fileno(stdout) || fd == fileno(stderr));
     // All other IOs are forbidden
   case SYS_read:
   case SYS_open:
@@ -124,13 +122,10 @@ static bool is_valid_io(pid_t pid) {
     return false;
   default:
     return true;
-  }*/
+  }
 }
 
 static bool is_syscall_io(pid_t pid) {
-  return false;
-// XXX Comment for now in AARCH64
-/*
   int syscallid = get_syscallid(pid);
   switch (syscallid) {
   case SYS_read:
@@ -145,7 +140,6 @@ static bool is_syscall_io(pid_t pid) {
   default:
     return false;
   }
-*/
 }
 
 static bool is_mru(void *addr) {

--- a/src/memory_dump/ptrace.c
+++ b/src/memory_dump/ptrace.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines       *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/ptrace.h
+++ b/src/memory_dump/ptrace.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines  *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/ptrace.h
+++ b/src/memory_dump/ptrace.h
@@ -25,12 +25,22 @@
 #include <sys/types.h>
 #include <sys/user.h>
 
+#include <sys/uio.h>
+#include <sys/ptrace.h>
+#include <asm/ptrace.h>
+
 #include "types.h"
 
 
 void ptrace_cont(pid_t pid);
+#if defined(__amd64__)
 void ptrace_setregs(pid_t pid, struct user_regs_struct *regs);
 void ptrace_getregs(pid_t pid, struct user_regs_struct *regs);
+#elif defined(__aarch64__)
+void ptrace_setregs(pid_t pid, struct user_pt_regs *regs);
+void ptrace_getregs(pid_t pid, struct user_pt_regs *regs);
+#endif
+
 void ptrace_getdata(pid_t pid, long readAddr, char * readBuf, int size);
 void ptrace_putdata(pid_t pid, long writeAddr, char * writeBuf, int size);
 void ptrace_syscall(pid_t pid);

--- a/src/memory_dump/tracee.c
+++ b/src/memory_dump/tracee.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2013-2016, Universite de Versailles St-Quentin-en-Yvelines  *
+ * Copyright (c) 2013-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/tracee.c
+++ b/src/memory_dump/tracee.c
@@ -123,7 +123,6 @@ void dump_close() { unlink("lel_bin"); }
  *  ...args...: the arguments to dump
  */
 void dump(char *loop_name, int invocation, int count, ...) {
-
   /* Must be conserved ? */
   /* Avoid doing something before initializing */
   /* the dump. */
@@ -132,11 +131,12 @@ void dump(char *loop_name, int invocation, int count, ...) {
 
   times_called++;
 
+
   /* Happens only once */
   if ((invocation <= PAST_INV && times_called == 1) ||
       (times_called == invocation - PAST_INV)) {
     mtrace_active = true;
-    send_to_tracer(0);
+    send_to_tracer(TRAP_LOCK_MEM);
   }
 
   if (times_called != invocation) {
@@ -146,9 +146,10 @@ void dump(char *loop_name, int invocation, int count, ...) {
   assert(times_called == invocation);
   mtrace_active = false;
 
-  /* Send args */
   strcpy(tracer_buff.str_tmp, loop_name);
-  send_to_tracer(0);
+
+  /* Send args */
+  send_to_tracer(TRAP_START_ARGS);
   send_to_tracer(invocation);
   send_to_tracer(count);
 
@@ -162,7 +163,7 @@ void dump(char *loop_name, int invocation, int count, ...) {
   va_end(ap);
 
   kill_after_dump = true;
-  send_to_tracer(0);
+  send_to_tracer(TRAP_END_ARGS);
 }
 
 void after_dump(void) {

--- a/src/memory_dump/tracee_interface.c
+++ b/src/memory_dump/tracee_interface.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines       *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *
@@ -26,12 +26,13 @@ static inline void sigtrap(void) {
 }
 
 void hook_sigtrap(void) {
-  asm volatile("mov %0,%%rax" : : "r"((register_t)SYS_hook));
+  asm volatile("mov %0,%%rsi" : : "r"((register_t)SYS_hook));
   sigtrap();
 }
 
-static void send_to_tracer(register_t arg) {
-  asm volatile("mov %0,%%rax" : : "r"((register_t)SYS_dump));
+void send_to_tracer(register_t arg) {
+  /* rdi and rsi are callee save */
+  asm volatile("mov %0,%%rsi" : : "r"((register_t)SYS_dump));
   asm volatile("mov %0,%%rdi" : : "r"(arg));
   sigtrap();
 }
@@ -64,15 +65,15 @@ void send_to_tracer(register_t arg) {
 }
 
 struct tracer_buff_t tracer_buff = {
-  .syscall = "\x01\x00\x00\xd4"           /* svc #0 syscall */
-             "\x00\x00\x20\xd4",          /* brk #0 (SIGTRAP) */
-  .unprotect_protect = "\x01\x00\x00\xd4" /* syscall protect */
+  .syscall = "\x01\x00\x00\xd4"           /* svc #0 syscall     */
+             "\x00\x00\x20\xd4",          /* brk #0 (SIGTRAP)   */
+  .unprotect_protect = "\x01\x00\x00\xd4" /* syscall protect    */
                        "\xe0\x03\x13\xaa" /* mov	x0, x19 */
                        "\xe1\x03\x14\xaa" /* mov	x1, x20 */
                        "\xe2\x03\x15\xaa" /* mov	x2, x21 */
                        "\xe8\x03\x16\xaa" /* mov	x8, x22 */
-                       "\x01\x00\x00\xd4" /* syscall unprotect */
-                       "\x00\x00\x20\xd4" /* brk #0 (SIGTRAP) */
+                       "\x01\x00\x00\xd4" /* syscall unprotect  */
+                       "\x00\x00\x20\xd4" /* brk #0 (SIGTRAP)   */
 };
 
 #endif

--- a/src/memory_dump/tracee_interface.c
+++ b/src/memory_dump/tracee_interface.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include "types.h"
 
+#if defined(__amd64__)
 static inline void sigtrap(void) {
   asm volatile("int $3");
 }
@@ -29,7 +30,7 @@ void hook_sigtrap(void) {
   sigtrap();
 }
 
-void send_to_tracer(register_t arg) {
+static void send_to_tracer(register_t arg) {
   asm volatile("mov %0,%%rax" : : "r"((register_t)SYS_dump));
   asm volatile("mov %0,%%rdi" : : "r"(arg));
   sigtrap();
@@ -46,3 +47,32 @@ struct tracer_buff_t tracer_buff = {
                        "\x0f\x05"     /* syscall unprotect */
                        "\xcc"         /* int $3 (SIGTRAP)  */
 };
+#elif defined(__aarch64__)
+static inline void sigtrap(void) {
+  asm volatile("brk #0");
+}
+
+void hook_sigtrap(void) {
+  asm volatile("mov x1, %0" : : "r"((register_t)SYS_hook) : "x1");
+  sigtrap();
+}
+
+void send_to_tracer(register_t arg) {
+  asm volatile("mov x1, %0" : : "r"((register_t)SYS_dump) : "x1");
+  asm volatile("mov x0, %0" : : "r"((register_t)arg) : "x0");
+  sigtrap();
+}
+
+struct tracer_buff_t tracer_buff = {
+  .syscall = "\x01\x00\x00\xd4"           /* svc #0 syscall */
+             "\x00\x00\x20\xd4",          /* brk #0 (SIGTRAP) */
+  .unprotect_protect = "\x01\x00\x00\xd4" /* syscall protect */
+                       "\xe0\x03\x13\xaa" /* mov	x0, x19 */
+                       "\xe1\x03\x14\xaa" /* mov	x1, x20 */
+                       "\xe2\x03\x15\xaa" /* mov	x2, x21 */
+                       "\xe8\x03\x16\xaa" /* mov	x8, x22 */
+                       "\x01\x00\x00\xd4" /* syscall unprotect */
+                       "\x00\x00\x20\xd4" /* brk #0 (SIGTRAP) */
+};
+
+#endif

--- a/src/memory_dump/tracer_interface.c
+++ b/src/memory_dump/tracer_interface.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines       *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/tracer_interface.c
+++ b/src/memory_dump/tracer_interface.c
@@ -117,13 +117,13 @@ int get_syscallid(pid_t pid) {
 bool is_hook_sigtrap(pid_t pid) {
   struct user_regs_struct regs;
   ptrace_getregs(pid, &regs);
-  return (regs.rax == SYS_hook);
+  return (regs.rsi == SYS_hook);
 }
 
 bool is_dump_sigtrap(pid_t pid) {
   struct user_regs_struct regs;
   ptrace_getregs(pid, &regs);
-  return (regs.rax == SYS_dump);
+  return (regs.rsi == SYS_dump);
 }
 
 void clear_trap(pid_t pid) {

--- a/src/memory_dump/tracer_interface.c
+++ b/src/memory_dump/tracer_interface.c
@@ -40,15 +40,13 @@
 
 #include "debug.h"
 
-#ifdef __x86_64__
-
-#define NB_MAX_ARGS 6
-
 
 extern struct tracer_buff_t * tracer_buff;
 
+#if defined(__amd64__)
+#define NB_MAX_ARGS 6
+
 /* arch/ABI   arg1   arg2   arg3   arg4   arg5   arg6   arg7  */
-/* ────────────────────────────────────────────────────────── */
 /* x86_64     rdi    rsi    rdx    r10    r8     r9      -    */
 static register_t inject_syscall(pid_t pid, int nb_args, register_t syscallid,
                                  ...) {
@@ -89,7 +87,6 @@ static register_t inject_syscall(pid_t pid, int nb_args, register_t syscallid,
 
   for (i = 0; i < nb_args; i++) {
     *(regs_ptr[i]) = va_arg(vargs, long long unsigned);
-
   }
   va_end(vargs);
 
@@ -129,16 +126,116 @@ bool is_dump_sigtrap(pid_t pid) {
   return (regs.rax == SYS_dump);
 }
 
-#endif
+void clear_trap(pid_t pid) {
+}
 
-#ifdef __arm__
-void inject_syscall(int syscallid, pid_t tid,
-                    struct user_regs_struct * regs->va_list vargs);
-#endif
+#elif defined(__aarch64__)
+#define NB_MAX_ARGS 6
 
-#ifdef __aarch64__
-void inject_syscall(int syscallid, pid_t tid,
-                    struct user_regs_struct * regs->va_list vargs);
+/* arch/ABI   arg1   arg2   arg3   arg4   arg5   arg6   arg7  */
+/* aarch64      x0     x1     x2     x3     x4     x5     -  */
+static register_t inject_syscall(pid_t pid, int nb_args, register_t syscallid,
+                                 ...) {
+
+  /* For the moment, we don't handle this case  */
+  assert(NB_MAX_ARGS >= nb_args);
+
+  /* We do the backup of registers */
+  long r;
+  register_t ret;
+  struct user_pt_regs regs, regs_backup;
+
+  ptrace_getregs(pid, &regs);
+  regs_backup = regs;
+
+  /* We get back arguments and adequately put them in registers */
+
+  int i = 0;
+  va_list vargs;
+  va_start(vargs, syscallid);
+
+  long long unsigned *regs_ptr[NB_MAX_ARGS] = {&(regs.regs[0]), &(regs.regs[1]),
+                                               &(regs.regs[2]), &(regs.regs[3]),
+                                               &(regs.regs[4]), &(regs.regs[5]),
+                                              };
+
+  regs.pc = (register_t)tracer_buff->syscall;
+  regs.regs[8] = syscallid;
+
+  if (syscallid == SYS_unprotect_protect) {
+    regs.pc = (register_t)tracer_buff->unprotect_protect;
+    regs.regs[8] = SYS_mprotect;
+    regs.regs[22] = SYS_mprotect;
+    regs_ptr[3] = &(regs.regs[19]);
+    regs_ptr[4] = &(regs.regs[20]);
+    regs_ptr[5] = &(regs.regs[21]);
+  }
+
+  for (i = 0; i < nb_args; i++) {
+    register_t r = va_arg(vargs, long long unsigned);
+    *(regs_ptr[i]) = r;
+  }
+  va_end(vargs);
+
+  // prepare registers for syscall
+  ptrace_setregs(pid, &regs);
+
+  // execute syscall in tracee
+  ptrace_cont(pid);
+
+  // wait for sigtrap in tracee
+  wait_event(pid);
+
+  // restore old registers
+  ptrace_getregs(pid, &regs);
+
+  ret = regs.regs[0];
+
+  ptrace_setregs(pid, &regs_backup);
+
+  return ret;
+}
+
+register_t get_arg_from_regs(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  return regs.regs[0];
+}
+
+int get_syscallid(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  return regs.regs[8];
+}
+
+bool is_hook_sigtrap(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  return (regs.regs[1] == SYS_hook);
+}
+
+bool is_dump_sigtrap(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  return (regs.regs[1] == SYS_dump);
+}
+
+void clear_trap(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  regs.pc +=4;
+  ptrace_setregs(pid, &regs);
+}
+
+void debug_regs(pid_t pid) {
+  struct user_pt_regs regs;
+  ptrace_getregs(pid, &regs);
+  fprintf(stderr, "register [pd] = %lld\n", regs.pc);
+  for (int i = 0; i < 9; i++) {
+    fprintf(stderr, "register [%d] = %lld\n", i, regs.regs[i]);
+  }
+}
+
 #endif
 
 void protect_i(pid_t pid, char *start, size_t size) {

--- a/src/memory_dump/tracer_interface.h
+++ b/src/memory_dump/tracer_interface.h
@@ -40,6 +40,6 @@ register_t get_arg_from_regs(pid_t pid);
 int get_syscallid(pid_t pid);
 bool is_dump_sigtrap(pid_t pid);
 bool is_hook_sigtrap(pid_t pid);
-
+void clear_trap(pid_t pid);
 
 #endif /* __TRACER_INTERFACE__H */

--- a/src/memory_dump/types.h
+++ b/src/memory_dump/types.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * This file is part of CERE.                                                *
  *                                                                           *
- * Copyright (c) 2016, Universite de Versailles St-Quentin-en-Yvelines       *
+ * Copyright (c) 2016-2017, Universite de Versailles St-Quentin-en-Yvelines  *
  *                                                                           *
  * CERE is free software: you can redistribute it and/or modify it under     *
  * the terms of the GNU Lesser General Public License as published by        *

--- a/src/memory_dump/types.h
+++ b/src/memory_dump/types.h
@@ -34,8 +34,17 @@
 #define SYS_hook (INT_MAX - 2)
 #define SYS_unprotect_protect (INT_MAX - 3)
 
+#define TRAP_LOCK_MEM 111
+#define TRAP_START_ARGS 112
+#define TRAP_END_ARGS 113
+
+#if defined(__amd64__)
 #define SIZE_SYSCALL_BIN (3 + 1)
 #define SIZE_UNPROTECT_PROTECT_BIN (23 + 1)
+#elif defined(__aarch64__)
+#define SIZE_SYSCALL_BIN (8 + 1)
+#define SIZE_UNPROTECT_PROTECT_BIN (28 + 1)
+#endif
 
 enum tracer_state_t {
   TRACER_UNLOCKED = 1,
@@ -50,7 +59,7 @@ struct tracer_buff_t {
   char syscall[SIZE_SYSCALL_BIN];
   char unprotect_protect[SIZE_UNPROTECT_PROTECT_BIN];
   char str_tmp[MAX_PATH];
-};
+} __attribute__ ((aligned(8), packed));
 
 typedef struct {
   int signo;


### PR DESCRIPTION
This PR tracks the porting effort of the ptrace memory tracer on Aarch64. Current tests are being performed on a Juno v1 rev board.