### PR TITLE
Fix race-condition at ptrace thread spawn

### DIFF
--- a/src/memory_dump/cere_tracer.c
+++ b/src/memory_dump/cere_tracer.c
@@ -367,6 +367,10 @@ pid_t handle_events_until_dump_trap(pid_t wait_for) {
       }
       ptrace_syscall(e.tid);
     }
+    else if (e.signo == SIGSTOP) {
+      /* A new thread is starting, ignore this event, next wait_event call will
+         unblock the thread once its parents registers it in tids array */
+    }
     else {
       errx(EXIT_FAILURE, "Unexpected signal in wait_sigtrap: %d\n", e.signo);
     }


### PR DESCRIPTION
The code that detects new spawned threads in the ptrace memory capture
did not consider the case where the new thread initial SIGSTOP signal was
caught before the parent SIGTRAP. This caused an unexpected signal trap.

This commit fixes this issue. Fixes #153.