### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,16 @@
 CERE CHANGELOG
 
+[v0.3.1] 2018/11/30
+    * Maintainance release, ensure all checks are passing with newer travis images
+
+[v0.3] 2017/10/12
+    * memory tracer: Fixed multiple race-conditions in ptrace functions attaching new threads.
+    * memory_tracer: Fixed a synchronization bug in send_to_tracer function
+    * Tested and validated CERE extraction on Lulesh Lawrence Livermore proto-application and on BWA gene alignment application
+    * Compatibility with LLVM 3.9
+    * Improved thread remapping formula for NUMA domains
+    * Support for ARMv8 complete (tested on Jetson, Juno and Thunder)
+
 [v0.2.2] 2016/06/06
     * Improved cere flag (add a stop/restart feature)
     * Fixed release version number

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CERE v0.3
+# CERE v0.3.1
 
 [![Build Status](https://travis-ci.org/benchmark-subsetting/cere.svg?branch=master)](https://travis-ci.org/benchmark-subsetting/cere)
 
@@ -93,7 +93,7 @@ file](https://github.com/benchmark-subsetting/cere/blob/master/THANKS).
 
 ### License and copyright
 
-Copyright (c) 2013-2017, Universite de Versailles St-Quentin-en-Yvelines
+Copyright (c) 2013-2018, Universite de Versailles St-Quentin-en-Yvelines
 
 CERE is free software: you can redistribute it and/or modify it under the terms of
 the GNU Lesser General Public License as published by the Free Software

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([cere], [0.3], [cere-dev@googlegroups.com])
+AC_INIT([cere], [0.3.1], [cere-dev@googlegroups.com])
 AM_SILENT_RULES([yes])
 AC_CONFIG_AUX_DIR(autoconf)
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
[v0.3.1] 2018/11/30
    * Maintainance release, ensure all checks are passing with newer travis images