### PR TITLE
Improve C++ support in standard mode

### DIFF
--- a/src/cere/lec.py
+++ b/src/cere/lec.py
@@ -345,4 +345,3 @@ def compile(args, args2):
     if objs:
       with open(args[0].cere_objects, "a") as text_file:
         text_file.write(objs)
-

--- a/src/cere/lel.py
+++ b/src/cere/lel.py
@@ -255,20 +255,23 @@ def original_fun(mode_opt, BINARY, COMPIL_OPT):
     Only call the linker
     '''
 
+    compiler = CLANG
+    if ".cpp" in COMPIL_OPT or ".cc" in COMPIL_OPT or ".cxx" in COMPIL_OPT:
+        compiler = CLANGPP
+
     if mode_opt.static:
         COMPIL_OPT += "-static"
 
     if(mode_opt.instrument_app):
         safe_system(("{link} -o {binary} {opts} {libs} {libdir}").format(
-              link=CLANG, binary=BINARY, opts=COMPIL_OPT, libs=PROFILE_LIB,
+              link=compiler, binary=BINARY, opts=COMPIL_OPT, libs=PROFILE_LIB,
               libdir=LIBDIR_FLAGS))
     elif(mode_opt.instrument):
         safe_system(("{link} -o {binary} {opts} {wrapper} {libdir}").format(
-              link=CLANG, binary=BINARY, opts=COMPIL_OPT,
+              link=compiler, binary=BINARY, opts=COMPIL_OPT,
               wrapper=mode_opt.wrapper, libdir=LIBDIR_FLAGS))
     else:
-        safe_system(("{link} -o {binary} {opts}").format(link=CLANG,
-                binary=BINARY, opts=COMPIL_OPT))
+        safe_system(("{link} {opts}").format(link=compiler, opts=COMPIL_OPT))
 
 
 def link(args):

--- a/src/cere/vars.py.in.in
+++ b/src/cere/vars.py.in.in
@@ -20,6 +20,7 @@ import os
 VERSION = "@PACKAGE_VERSION@"
 FORTRAN_SUPPORT="@FORTRAN_SUPPORT@"
 CLANG = os.path.join("@LLVM_BINDIR@","clang")
+CLANGPP = os.path.join("@LLVM_BINDIR@","clang++")
 PPROF = "@PPROF@"
 LLVM_BINDIR = "@LLVM_BINDIR@"
 GCC="@GCC_PATH@"
@@ -41,7 +42,7 @@ LIKWID = "-llikwid"
 FORTRAN_EXTENSIONS=[".f", ".f90", ".f77", ".F90"]
 DUMPS_DIR = ".cere/dumps/"
 
-SOURCE_EXTENSIONS=[".C", ".c", ".cpp", ".cc"] + FORTRAN_EXTENSIONS
+SOURCE_EXTENSIONS=[".C", ".c", ".cpp", ".cc", ".cxx"] + FORTRAN_EXTENSIONS
 
 INVALID_REGION_FILE = "invalid_regions"
 


### PR DESCRIPTION
We now use lel with clang++ if needed and detect .cxx as a valid C++ file extension.