### PR TITLE
Integrate per-codelet invocation counter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS=src/ tests/ doc/
+SUBDIRS=src/ tests/
 ACLOCAL_AMFLAGS=-I m4
 EXTRA_DIST=examples/
 dist_bin_SCRIPTS=cere

--- a/src/memory_dump/cere_tracer.c
+++ b/src/memory_dump/cere_tracer.c
@@ -47,7 +47,7 @@
 #endif
 
 #define _DEBUG 1
-// #undef _DEBUG
+#undef _DEBUG
 
 
 #include "debug.h"
@@ -393,7 +393,7 @@ pid_t handle_events_until_dump_trap(pid_t wait_for) {
       continue;
     }
     else {
-      errx(EXIT_FAILURE, "Unexpected signal in wait_sigtrap: %d\n", e.signo);
+      errx(EXIT_FAILURE, "Unexpected signal in wait_sigtrap: %d, (%d, %d)\n", e.signo, getpid(), getppid());
     }
   }
   debug_print("%s", "\n");
@@ -888,6 +888,9 @@ void sigabrt_handler(int signo, siginfo_t *si, void *data) {
     // Detach from the tracee and resume it
     unfollow_threads(pid);
 
+    int status;
+    pid_t child_pid = waitpid(pid, &status, 0);
+    debug_print("[tracer %d]: after waiting for tracee %d(%d)\n", getpid(), child_pid, pid);
     debug_print("[tracer %d] Killing ourselves\n", getpid());
     exit(0);
   }

--- a/src/memory_dump/tracee.h
+++ b/src/memory_dump/tracee.h
@@ -27,6 +27,9 @@
 /* dump_init: initialises the memory tracer. Must be called at the very begin
  * of the tracee execution. Ideally it should be the first thing done in the
  * tracee main() */
+void dump_preinit(void);
+void multi_dump_preinit(void);
+
 void dump_init(void);
 void multi_dump_init(void);
 
@@ -45,7 +48,7 @@ void dump(char *loop_name, int invocation, int arg_count, ...);
 
 /* after_dump: terminates capture of a region of interest. must be called
    at the end of the function to be captured */
-void after_dump(void);
+void after_dump(char* loop_name, int invocation);
 
 /* mtrace_active: true when the memory protection hooks in hooks.c are
  * active */


### PR DESCRIPTION
- updated after_dump() api for dump() matching
- added waitpid() to ensure tracer/tracee stops together.
- added per loop invocation counting.